### PR TITLE
Refactor functors and related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bugfixes:
 Other improvements:
   - Migrated CI to GitHub Actions and updated installation instructions to use Spago (#14)
   - Added a CHANGELOG.md file and pull request template (#15, #16)
+  - This package now depends on the `purescript-tuples` and `purescript-type-equality` packages, and contains an instance previously in `purescript-tuples` (#17)
 
 ## [v4.0.0](https://github.com/purescript/purescript-distributive/releases/tag/v4.0.0) - 2018-05-23
 

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "purescript-identity": "master",
     "purescript-newtype": "master",
-    "purescript-prelude": "master"
+    "purescript-prelude": "master",
+    "purescript-tuples": "master",
+    "purescript-type-equality": "master"
   }
 }

--- a/src/Data/Distributive.purs
+++ b/src/Data/Distributive.purs
@@ -4,6 +4,8 @@ import Prelude
 
 import Data.Identity (Identity(..))
 import Data.Newtype (unwrap)
+import Data.Tuple (Tuple(..), snd)
+import Type.Equality (class TypeEquals, from)
 
 -- | Categorical dual of `Traversable`:
 -- |
@@ -30,6 +32,10 @@ instance distributiveIdentity :: Distributive Identity where
 instance distributiveFunction :: Distributive ((->) e) where
   distribute a e = map (_ $ e) a
   collect f = distribute <<< map f
+
+instance distributiveTuple :: TypeEquals a Unit => Distributive (Tuple a) where
+  collect = collectDefault
+  distribute = Tuple (from unit) <<< map snd
 
 -- | A default implementation of `distribute`, based on `collect`.
 distributeDefault


### PR DESCRIPTION
This is part of a set of commits that rearrange the dependencies between
multiple packages. The immediate motivation is to allow certain newtypes
to be reused between `profunctor` and `bifunctors`, but this particular
approach goes a little beyond that in two ways: first, it attempts to
move data types (`either`, `tuple`) toward the bottom of the dependency
stack; and second, it tries to ensure no package comes between
`functors` and the packages most closely related to it, in order to open
the possibility of merging those packages together (which may be
desirable if at some point in the future additional newtypes are added
which reveal new and exciting constraints on the module dependency
graph).

**Description of the change**

See discussion in purescript/purescript-profunctor#23.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
